### PR TITLE
Package not works after 'navigator-godef' rename

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,7 +24,7 @@ module.exports = {
       this.dependenciesInstalled = true;
       return this.dependenciesInstalled;
     }).then(() => {
-      var godefModule = atom.packages.getLoadedPackage('navigator-godef');
+      var godefModule = atom.packages.getLoadedPackage('navigator-go');
       if (godefModule && godefModule.mainModulePath) {
         this.godef = require(godefModule.mainModulePath).godef;
       }
@@ -65,7 +65,7 @@ module.exports = {
         return {
           range,
           callback() {
-            // call func from module `navigator-godef`
+            // call func from module `navigator-go`
             var endOffset = textEditor.getBuffer().characterIndexForPosition(range.end);
             godef.gotoDefinitionWithParameters(['-o', endOffset, '-i'], textEditor.getText())
           },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "atom-package-deps": "^4.0.1"
   },
   "package-deps": [
-    "navigator-godef"
+    "navigator-go"
   ],
   "providedServices": {
     "hyperclick.provider": {


### PR DESCRIPTION
On 'navigator-godef' lastest release (v1.1.3), the main developer has decided change the name of this package from 'navigator-godef' to 'navigator-go'. After update this, 'go-hyperclick' stops working properly.

I found the solution to the problem, so I'll proceed to create the fix.
